### PR TITLE
feat: update to macOS 14 to use the new `onChange` with `{ oldValue, newValue in ...`

### DIFF
--- a/Sources/DebouncedOnChange/DebouncedChangeViewModifier.swift
+++ b/Sources/DebouncedOnChange/DebouncedChangeViewModifier.swift
@@ -15,59 +15,37 @@ extension View {
     ///   - action: A closure to run when the value changes.
     /// - Returns: A view that fires an action after debounced time when the specified value changes.
     @available(iOS 16.0, *)
-    @available(macOS 13.0, *)
+    @available(macOS 14.0, *)
     @available(tvOS 16.0, *)
     @available(watchOS 9.0, *)
     public func onChange<Value>(
         of value: Value,
         debounceTime: Duration,
-        perform action: @escaping (_ newValue: Value) -> Void
+        perform action: @escaping (_ oldValue: Value, _ newValue: Value) -> Void
     ) -> some View where Value: Equatable {
         self.modifier(DebouncedChangeViewModifier(trigger: value, action: action) {
             try await Task.sleep(for: debounceTime)
         })
     }
-
-    /// Adds a modifier for this view that fires an action only when a time interval in seconds represented by
-    /// `debounceTime` elapses between value changes.
-    ///
-    /// Each time the value changes before `debounceTime` passes, the previous action will be cancelled and the next
-    /// action will be scheduled to run after that time passes again. This mean that the action will only execute
-    /// after changes to the value stay unmodified for the specified `debounceTime` in seconds.
-    ///
-    /// - Parameters:
-    ///   - value: The value to check against when determining whether to run the closure.
-    ///   - debounceTime: The time in seconds to wait after each value change before running `action` closure.
-    ///   - action: A closure to run when the value changes.
-    /// - Returns: A view that fires an action after debounced time when the specified value changes.
-    @available(iOS, deprecated: 16.0, message: "Use version of this method accepting Duration type as debounceTime")
-    @available(macOS, deprecated: 13.0, message: "Use version of this method accepting Duration type as debounceTime")
-    @available(tvOS, deprecated: 16.0, message: "Use version of this method accepting Duration type as debounceTime")
-    @available(watchOS, deprecated: 9.0, message: "Use version of this method accepting Duration type as debounceTime")
-    public func onChange<Value>(
-        of value: Value,
-        debounceTime: TimeInterval,
-        perform action: @escaping (_ newValue: Value) -> Void
-    ) -> some View where Value: Equatable {
-        self.modifier(DebouncedChangeViewModifier(trigger: value, action: action) {
-            try await Task.sleep(seconds: debounceTime)
-        })
-    }
 }
 
+@available(iOS 16.0, *)
+@available(macOS 14.0, *)
+@available(tvOS 16.0, *)
+@available(watchOS 9.0, *)
 private struct DebouncedChangeViewModifier<Value>: ViewModifier where Value: Equatable {
     let trigger: Value
-    let action: (Value) -> Void
+    let action: (Value, Value) -> Void
     let sleep: @Sendable () async throws -> Void
 
     @State private var debouncedTask: Task<Void, Never>?
 
     func body(content: Content) -> some View {
-        content.onChange(of: trigger) { value in
+        content.onChange(of: trigger) { oldValue, value in
             debouncedTask?.cancel()
             debouncedTask = Task {
                 do { try await sleep() } catch { return }
-                action(value)
+                action(oldValue, value)
             }
         }
     }

--- a/Sources/DebouncedOnChange/DebouncedChangeViewModifier.swift
+++ b/Sources/DebouncedOnChange/DebouncedChangeViewModifier.swift
@@ -38,7 +38,7 @@ private struct DebouncedChangeViewModifier<Value>: ViewModifier where Value: Equ
     let action: (Value, Value) -> Void
     let sleep: @Sendable () async throws -> Void
 
-    @State private var debouncedTask: Task<Void, Never>?
+    @State public var debouncedTask: Task<Void, Never>?
 
     func body(content: Content) -> some View {
         content.onChange(of: trigger) { oldValue, newValue in

--- a/Sources/DebouncedOnChange/DebouncedChangeViewModifier.swift
+++ b/Sources/DebouncedOnChange/DebouncedChangeViewModifier.swift
@@ -41,11 +41,11 @@ private struct DebouncedChangeViewModifier<Value>: ViewModifier where Value: Equ
     @State private var debouncedTask: Task<Void, Never>?
 
     func body(content: Content) -> some View {
-        content.onChange(of: trigger) { oldValue, value in
+        content.onChange(of: trigger) { oldValue, newValue in
             debouncedTask?.cancel()
             debouncedTask = Task {
                 do { try await sleep() } catch { return }
-                action(oldValue, value)
+                action(oldValue, newValue)
             }
         }
     }

--- a/Sources/DebouncedOnChange/DebouncedTaskViewModifier.swift
+++ b/Sources/DebouncedOnChange/DebouncedTaskViewModifier.swift
@@ -18,7 +18,7 @@ extension View {
     /// - Returns: A view that runs the specified action asynchronously before the view appears, or restarts the task
     ///     with the id value changes after debounced time.
     @available(iOS 16.0, *)
-    @available(macOS 13.0, *)
+    @available(macOS 14.0, *)
     @available(tvOS 16.0, *)
     @available(watchOS 9.0, *)
     public func task<T>(


### PR DESCRIPTION
fixes #2